### PR TITLE
Cache control in headers

### DIFF
--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -5,9 +5,17 @@ export async function GET() {
   try {
     const companies = await getCompanies();
 
-    return NextResponse.json({
-      companies: companies.map((c) => c.name),
-    });
+    return NextResponse.json(
+      {
+        companies: companies.map((c) => c.name),
+      },
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "public, max-age=3600, stale-while-revalidate=60",
+        },
+      }
+    );
   } catch (error) {
     console.error("Error fetching companies:", error);
     return NextResponse.json({ error: "Failed to load companies from database" }, { status: 500 });

--- a/app/api/questions/route.ts
+++ b/app/api/questions/route.ts
@@ -42,11 +42,19 @@ export async function GET(request: Request) {
       offset,
     });
 
-    return NextResponse.json({
-      questions: result.questions,
-      companies: result.companies,
-      totalCount: result.totalCount,
-    });
+    return NextResponse.json(
+      {
+        questions: result.questions,
+        companies: result.companies,
+        totalCount: result.totalCount,
+      },
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "public, max-age=3600, stale-while-revalidate=60",
+        },
+      }
+    );
   } catch (error) {
     console.error("Error fetching questions:", error);
     return NextResponse.json({ error: "Failed to load questions from database" }, { status: 500 });


### PR DESCRIPTION
https://codejeet.com/dashboard , currently takes a couple of seconds to load since response from https://codejeet.com/api/questions is too big 
used cache control to cache the response for an hour with 1 min revalidation window

PS: future improvement,  paginate the responses or something to reduce the payload size