### PR TITLE
Add noindex to filter and compare pages

### DIFF
--- a/app/company/[slug]/[filter]/page.tsx
+++ b/app/company/[slug]/[filter]/page.tsx
@@ -76,6 +76,7 @@ export async function generateMetadata({
         `Practice ${count} ${topicLabel} problems asked at ${displayName}. ` +
         `Filter by difficulty and frequency. Sorted by interview frequency.`,
       alternates: { canonical: `https://codejeet.com/company/${slug}/${filter}` },
+      robots: { index: false, follow: true },
       openGraph: {
         title: `${displayName} ${topicLabel} Interview Questions | CodeJeet`,
         description: `Browse ${count} ${topicLabel} LeetCode problems asked at ${displayName}.`,
@@ -96,6 +97,7 @@ export async function generateMetadata({
         `Practice ${count} ${diffLabel.toLowerCase()} difficulty problems asked at ${displayName}. ` +
         `Sorted by interview frequency.`,
       alternates: { canonical: `https://codejeet.com/company/${slug}/${filter}` },
+      robots: { index: false, follow: true },
       openGraph: {
         title: `${displayName} ${diffLabel} Interview Questions | CodeJeet`,
         description: `Browse ${count} ${diffLabel.toLowerCase()} LeetCode problems asked at ${displayName}.`,

--- a/app/compare/[pair]/page.tsx
+++ b/app/compare/[pair]/page.tsx
@@ -40,7 +40,6 @@ export async function generateMetadata({
       `${companyB.displayName} (${companyB.questionCount} questions). ` +
       `${sharedCount} shared LeetCode problems.`,
     alternates: { canonical: `https://codejeet.com/compare/${pair}` },
-    robots: { index: false, follow: true },
     openGraph: {
       title: `${companyA.displayName} vs ${companyB.displayName} | CodeJeet`,
       description:

--- a/app/compare/[pair]/page.tsx
+++ b/app/compare/[pair]/page.tsx
@@ -40,6 +40,7 @@ export async function generateMetadata({
       `${companyB.displayName} (${companyB.questionCount} questions). ` +
       `${sharedCount} shared LeetCode problems.`,
     alternates: { canonical: `https://codejeet.com/compare/${pair}` },
+    robots: { index: false, follow: true },
     openGraph: {
       title: `${companyA.displayName} vs ${companyB.displayName} | CodeJeet`,
       description:


### PR DESCRIPTION
## Summary
- Add `robots: { index: false, follow: true }` to `/company/[slug]/[filter]` (topic + difficulty views) and `/compare/[pair]` pages
- Preserves crawl budget by preventing Google from indexing thin/parameterized filter pages while still following links
- Cherry-picked from #31 (the useful SEO parts only — skipped the harmful `robots.ts` change and outdated `sitemap.ts` change)