### PR TITLE
add .env.example and LintCode links for premium problems

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy to .env.local for `pnpm dev`. Leave blank for browse-only local use.
+# Auth, progress sync, and podcast audio need the keys below.
+
+# --- Clerk (optional; only needed to save progress / notes cloud sync) ---
+# Dev keys from https://dashboard.clerk.com (Development instance).
+# Publishable key is inlined at build time. Secret stays server-side.
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+
+# Worker local runtime (`pnpm preview` / `wrangler dev`) reads secrets from
+# .dev.vars, not .env.local. Mirror the two Clerk vars there when testing
+# the Cloudflare worker. Production secret: wrangler secret put CLERK_SECRET_KEY
+
+# --- Optional: podcast audio CDN ---
+# Public R2 base URL for system-design audiobook playback. App works without it.
+NEXT_PUBLIC_R2_BASE_URL=
+
+# --- Optional: blog generation scripts only (not used by the app runtime) ---
+# DEEPSEEK_API_KEY=
+# LIQUIDSLR_DIR=

--- a/components/LeetCodeDashboard.tsx
+++ b/components/LeetCodeDashboard.tsx
@@ -28,7 +28,7 @@ import { DifficultyBadge } from "@/components/ui/difficulty-badge";
 import TopicDropdown from "@/components/TopicDropdown";
 import { toDisplayRow, type DashboardIndex } from "@/lib/dashboard/decode";
 import { computeStats, filterLinks, sortLinks, type SortOrder } from "@/lib/dashboard/query";
-import { LEETCODE_BASE_URL, type Difficulty, type Timeframe } from "@/lib/dashboard/schema";
+import { type Difficulty, type Timeframe } from "@/lib/dashboard/schema";
 
 interface LeetCodeDashboardProps {
   index: DashboardIndex | null;
@@ -568,9 +568,14 @@ const LeetCodeDashboard: React.FC<LeetCodeDashboardProps> = ({
                           </TableCell>
                           <TableCell>
                             <a
-                              href={`${LEETCODE_BASE_URL}${row.path}`}
+                              href={row.url}
                               target="_blank"
                               rel="noopener noreferrer"
+                              title={
+                                row.premium
+                                  ? "Open on LintCode (LeetCode premium)"
+                                  : "Open on LeetCode"
+                              }
                               className="text-foreground hover:text-primary hover:underline"
                             >
                               {row.title}
@@ -684,9 +689,14 @@ const LeetCodeDashboard: React.FC<LeetCodeDashboardProps> = ({
                           />
                           <div>
                             <a
-                              href={`${LEETCODE_BASE_URL}${row.path}`}
+                              href={row.url}
                               target="_blank"
                               rel="noopener noreferrer"
+                              title={
+                                row.premium
+                                  ? "Open on LintCode (LeetCode premium)"
+                                  : "Open on LeetCode"
+                              }
                               className="font-medium hover:underline"
                             >
                               {row.title}

--- a/lib/dashboard/decode.ts
+++ b/lib/dashboard/decode.ts
@@ -1,6 +1,7 @@
 import {
   DIFFICULTIES,
   formatPercent,
+  practiceUrl,
   problemPath,
   type DashboardPayload,
   type Difficulty,
@@ -53,6 +54,8 @@ export interface DisplayRow {
   slug: string;
   title: string;
   path: string;
+  /** External practice URL (LeetCode free, LintCode by slug for premium). */
+  url: string;
   difficulty: Difficulty;
   /** Brand-cased company label (not the slug). */
   company: string;
@@ -65,17 +68,19 @@ export interface DisplayRow {
 export function toDisplayRow(index: DashboardIndex, linkIndex: number): DisplayRow {
   const [problem, company, frequency] = index.links[linkIndex];
   const [slug, title, difficulty, acceptance, premium, topics] = index.problems[problem];
+  const isPremium = premium === 1;
 
   return {
     key: String(linkIndex),
     slug,
     title,
     path: problemPath(slug),
+    url: practiceUrl(isPremium, title, slug),
     difficulty: DIFFICULTIES[difficulty],
     company: index.companyNames[company],
     acceptance: formatPercent(acceptance),
     frequency: formatPercent(frequency),
     topics: topics.map((topic) => index.topics[topic]),
-    premium: premium === 1,
+    premium: isPremium,
   };
 }

--- a/lib/dashboard/schema.ts
+++ b/lib/dashboard/schema.ts
@@ -10,6 +10,7 @@ export const TIMEFRAMES = ["all", "30_days", "3_months", "6_months", "more_than_
 export type Timeframe = (typeof TIMEFRAMES)[number];
 
 export const LEETCODE_BASE_URL = "https://leetcode.com";
+export const LINTCODE_BASE_URL = "https://www.lintcode.com";
 
 export type EncodedProblem = [
   slug: string,
@@ -70,4 +71,17 @@ export function problemPath(slug: string): string {
 
 export function problemUrl(slug: string): string {
   return `${LEETCODE_BASE_URL}${problemPath(slug)}`;
+}
+
+/**
+ * LintCode problem page by LeetCode-style slug (singular /problem/, not /problems/).
+ * Matching slugs redirect to numeric IDs (e.g. /problem/two-sum/ → /problem/56/).
+ */
+export function lintcodeProblemUrl(slug: string): string {
+  return `${LINTCODE_BASE_URL}/problem/${slug}/`;
+}
+
+/** External practice link: free → LeetCode, premium → LintCode (same slug). */
+export function practiceUrl(premium: boolean, _title: string, slug: string): string {
+  return premium ? lintcodeProblemUrl(slug) : problemUrl(slug);
 }

--- a/tests/dashboard-decode.test.ts
+++ b/tests/dashboard-decode.test.ts
@@ -62,6 +62,7 @@ describe("toDisplayRow", () => {
       slug: "two-sum",
       title: "Two Sum",
       path: "/problems/two-sum",
+      url: "https://leetcode.com/problems/two-sum",
       difficulty: "Easy",
       company: "Google",
       acceptance: "54.3%",
@@ -78,6 +79,17 @@ describe("toDisplayRow", () => {
     assert.equal(row.frequency, "7.5%");
     assert.equal(row.difficulty, "Hard");
     assert.equal(row.premium, true);
+  });
+
+  it("points free rows at LeetCode and premium rows at LintCode by slug", () => {
+    const free = toDisplayRow(index, 0);
+    const premium = toDisplayRow(index, 1);
+
+    assert.equal(free.url, "https://leetcode.com/problems/two-sum");
+    assert.equal(
+      premium.url,
+      "https://www.lintcode.com/problem/median-of-two-sorted-arrays/"
+    );
   });
 
   it("gives every row a unique key even when two links share a problem and company", () => {


### PR DESCRIPTION
## Summary
- Add `.env.example` documenting Clerk, optional R2, and script-only env vars for local setup (#7).
- Premium dashboard rows link to LintCode by LeetCode-style slug (`/problem/<slug>/`); free rows still open LeetCode (#14).

## Notes
- LintCode redirects matching slugs to numeric IDs (verified for common problems). Mismatched/missing slugs may 404 on LintCode.
- Closes leftover setup/docs and premium-alternate issues after triage to 0 open issues.